### PR TITLE
不要なファイルを作らないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,13 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Don't generate system test files.
+    config.generators.system_tests = nil
+    config.generators do |g|
+      g.skip_routes true
+      g.helper false
+      g.test_framework nil
+    end
   end
 end


### PR DESCRIPTION
config/application.rbファイルに不要なファイルを作らないように設定を追加

- ルーティングの記述を加えないようにする設定。
- ヘルパーファイルを自動生成しないようにする設定。
- テストフレームワークを使わないようにする設定。