### PR TITLE
フラッシュメッセージ実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
 
+  add_flash_types :success, :danger
+
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,14 +7,15 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_to root_path
+      redirect_to root_path, success: 'ログインしました'
     else
-      render :new
+      flash.now[:danger] = 'ログインに失敗しました'
+      render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
-    redirect_to root_path, status: :see_other
+    redirect_to root_path, status: :see_other, success: 'ログアウトしました'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path
+      redirect_to root_path, success: 'ユーザー登録が完了しました'
     else
-      render :new
+      flash.now[:danger] = 'ユーザー登録に失敗しました'
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def flash_color(type)
+    case type.to_sym
+      when :success then "blue"
+      when :danger  then "red"
+      else "gray"
+    end
+  end
 end

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,0 +1,8 @@
+<% flash.each do |message_type, message| %>
+  <div class="bg-<%= flash_color(message_type) %>-100 border border-<%= flash_color(message_type) %>-400 text-<%= flash_color(message_type) %>-700 px-4 py-3 rounded relative" role="alert">
+    <strong class="font-bold"><%= message %></strong>
+    <span class="absolute top-0 bottom-0 right-0 px-4 py-3">
+      <svg class="fill-current h-6 w-6 text-<%= flash_color(message_type) %>-500" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
+    </span>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
+    <%= render 'layouts/flash_messages' %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -47,11 +47,7 @@
     <div class="max-w-md flex flex-col mx-auto text-center">
         <h1 class="mb-5 text-5xl font-bold">Review Refrect</h1>
         <p class="mb-5">感情を言葉にしよう</p>
-        <button class="btn btn-primary">
-            <%= link_to 'ログイン', login_path %>
-        </button>
-        <button class="btn btn-link">
-            <%= link_to '新規登録', new_user_path %>
-        </button>
+        <%= link_to 'ログイン', login_path, class: "btn btn-primary" %>
+        <%= link_to '新規登録', new_user_path, class: "btn btn-link" %>
     </div>
 </div>


### PR DESCRIPTION
- 仕様
  - ヘッダーの下にフラッシュメッセージバナーが表示されるようにする。
  - 成功：青、失敗：赤のバナーが表示される
  - ログイン
    - ログイン成功「ログインしました」
    - ログイン失敗「ログインに失敗しました」
  - ユーザー登録
    - 登録成功「ユーザー登録が完了しました」
    - 登録失敗「ユーザー登録に失敗しました」

- 実装内容
  - Tailwindのアラートテンプレート使用
  - 色の切り替えはヘルパーにて