### PR TITLE
手動レビューまとめ機能実装

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -4,11 +4,18 @@ class ReviewsController < ApplicationController
   end
 
   def new
-    @review = Review.new
-    session[:review_id] = nil
+    @review = current_user.reviews.find(session[:review_id])
   end
 
-  def create
+  def show
+    @review = Review.find(params[:id])
+    @conversations = @review.conversations
+  end
+
+  def edit
+  end
+
+  def update
     @review = Review.find_by(id: session[:review_id], user_id: current_user.id)
     
     if @review.update(review_params)
@@ -17,19 +24,6 @@ class ReviewsController < ApplicationController
       flash.now[:danger] = "レビューをまとめられませんでした"
       render :new, status: :unprocessable_entity
     end
-  end
-
-  def show
-    @board = Board.find(params[:id])
-  end
-
-  def edit
-    @review = current_user.reviews.find(params[:id])
-    @conversations = @review.conversations.order(created_at: :asc)    
-  end
-
-  def updated
-
   end
 
   private

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,1 +1,8 @@
-show
+<div class="card bg-base-100 w-96 shadow-xl mb-4 mx-auto">
+  <div class="card-body">
+    <p><%= l @review.created_at, format: :short %></p>  
+    <h2 class="card-title"><%= @review.title %></h2>
+    <p><%= @review.summary %></p>
+  </div>
+</div>
+<%= render partial: 'conversations/conversation', collection: @conversations %>


### PR DESCRIPTION
# 概要

- レビューを手動保存できる機能の実装

# テストケース

- [ ] レビューをまとめるボタンを押下するとレビューまとめフォームが表示される
- [ ] タイトル・レビューを入力すると保存できる
- [ ] 入力後、レビュー詳細ページに遷移する・成功メッセージが表示される
- [ ] バリデーションエラー時、ページ遷移せずにエラーメッセージが表示される