### PR TITLE
redisとsidekiqの削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem "cssbundling-rails"
 gem "jbuilder"
 
 # Use Redis adapter to run Action Cable in production
-gem "redis"
+# gem "redis"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
@@ -74,5 +74,4 @@ end
 gem "dockerfile-rails", ">= 1.6", :group => :development
 gem 'dotenv-rails'
 gem 'ruby-openai'
-gem "sidekiq"
 gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,10 +234,6 @@ GEM
     rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
-    redis (5.2.0)
-      redis-client (>= 0.22.0)
-    redis-client (0.22.2)
-      connection_pool
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
@@ -254,12 +250,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (7.3.0)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -323,10 +313,8 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
-  redis
   ruby-openai
   selenium-webdriver
-  sidekiq
   sorcery (= 0.16.3)
   sprockets-rails
   stimulus-rails

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,5 @@ module Myapp
       g.helper false
       g.test_framework nil
     end
-
-    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,0 @@
-Sidekiq.configure_server do |config|
-  config.redis = { url: 'redis://redis:6379' }
-end
-
-Sidekiq.configure_client do |config|
-  config.redis = { url: 'redis://redis:6379' }
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,19 +1,9 @@
-require 'sidekiq/web'
-
 Rails.application.routes.draw do
-  Sidekiq::Web.use(Rack::Auth::Basic) do |user_id, password|
-    [user_id, password] == [ENV['SIDEKIQ_BASIC_ID'], ENV['SIDEKIQ_BASIC_PASSWORD']]
-  end
-  mount Sidekiq::Web => '/sidekiq'
   
   root 'staticpages#top'
   resources :users, only: %i[new create]
   resources :reviews
-  resources :conversations do
-    collection do
-      post 'query'
-    end
-  end
+  resources :conversations
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,0 @@
-:concurrency: 3
-:queues:
-  - default

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,0 @@
-10.times do |index|
-  user = User.find(1)
-  user.reviews.create!(title: "title#{index}", summary: "summary#{index}")
-end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,34 +33,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      redis:
-        condition: service_healthy
-  sidekiq:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
-    command: bundle exec sidekiq
-    volumes:
-      - .:/myapp
-      - bundle_data:/usr/local/bundle:cached
-      - node_modules:/myapp/node_modules
-    environment:
-      TZ: Asia/Tokyo
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy  
-  redis:
-    image: redis
-    restart: always
-    ports:
-      - "6379:6379"
-    healthcheck:
-      test: ['CMD', 'redis-cli', 'ping']
-      interval: 10s
-      timeout: 5s
-      retries: 3
 volumes:
   bundle_data:
   postgresql_data:


### PR DESCRIPTION
使用をやめたため関連コードなどを削除

- Gem削除（redis, sidekiq）
- docker-compose.yml修正（redis, sidekiqコンテナの削除）
- sidekiq設定関連のファイル・記述の削除
- jobの削除