### PR TITLE
fly.io再デプロイ時の問題修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,12 @@ RUN yarn install --frozen-lockfile
 COPY . .
 
 # Precompile bootsnap code for faster boot times
-RUN bundle exec bootsnap precompile app/ lib/
+# RUN bundle exec bootsnap precompile app/ lib/
+RUN bundle exec bootsnap precompile --gemfile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
-
+# RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
 
 # Final stage for app image
 FROM base
@@ -72,4 +73,4 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-CMD ["./bin/rails", "server"]
+CMD ["./bin/rails", "server", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,4 +73,4 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-CMD ["./bin/rails", "server", "-b", "0.0.0.0"]
+CMD ["./bin/rails", "server"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,7 +1,7 @@
 # fly.toml app configuration file generated for review-reflect on 2024-07-04T21:28:03+09:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
-#
+#    path = '/up' checks.statusから抜いた
 
 app = 'review-reflect'
 primary_region = 'nrt'
@@ -28,7 +28,6 @@ console_command = '/rails/bin/rails console'
     timeout = '2s'
     grace_period = '5s'
     method = 'GET'
-    path = '/up'
     protocol = 'http'
     tls_skip_verify = false
 


### PR DESCRIPTION
デプロイ時のエラー対応
現象：マシンのヘルスチェックが終わらずタイムアウトになる
原因：fly.tomlのチェック項目に必要のないエンドポイントが追加されていた
対応：checks.statusから` path = '/up'を削除