### PR TITLE
共通部分のデザイン修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,10 @@ module ApplicationHelper
       else "gray"
     end
   end
+
+  def page_title(title = '')
+    if title.present?
+      "#{title}"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,9 +7,12 @@ module ApplicationHelper
     end
   end
 
-  def page_title(title = '')
+  def page_title(title = '', include_base: true)
+    base_title = "Review Reflect"
     if title.present?
-      "#{title}"
+      include_base ? "#{base_title} | #{title}" : title
+    else
+      base_title
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Review Reflect</title>
+    <title>Review Reflect | <%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -11,13 +11,15 @@
   </head>
 
   <body>
-    <% if logged_in? %>
-      <%= render 'shared/header' %>
-    <% else %>
-      <%= render 'shared/before_login_header' %>
-    <% end %>
-    <%= render 'layouts/flash_messages' %>
-    <%= yield %>
-    <%= render 'shared/footer' %>
+    <div class="wrapper min-h-screen pb-60 relative box-border">
+      <% if logged_in? %>
+        <%= render 'shared/header' %>
+      <% else %>
+        <%= render 'shared/before_login_header' %>
+      <% end %>
+      <%= render 'layouts/flash_messages' %>
+      <%= yield %>
+      <%= render 'shared/footer' %>
+    </div>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Review Reflect | <%= page_title(yield(:title)) %></title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, 'レビュー編集') %>
 <%= turbo_frame_tag "edit-review" do %>
   <div id="edit-review" class="w-96 mx-auto">
     <%= render 'form', review: @review %>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, 'レビューをみる') %>
 <div>
   <% if @reviews.present? %>
     <%= render @reviews %>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, 'レビューをつくる') %>
 <%= turbo_frame_tag "edit-review" do %>
   <div class="mx-auto w-full flex">
     <div class="mx-auto">
@@ -17,3 +18,8 @@
     </div>
   </div>
 <% end %>
+<style>
+    .footer {
+        display: none;
+    }
+</style>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, @review.title) %>
 <div class="card bg-base-100 w-96 shadow-xl mb-4 mx-auto">
   <div class="card-body">
     <p><%= l @review.created_at, format: :short %></p>  

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <header>
-  <div class="navbar bg-base-100">
-    <div class="navbar-start">
+  <div class="flex items-center justify-between h-12 px-4 bg-base-200">
+    <%= link_to :back, class: "flex-shrink-0" do %>
       <svg 
         xmlns="http://www.w3.org/2000/svg"
         class="h-5 w-5"
@@ -12,9 +12,10 @@
           strokeLinejoin="round"
           d="M15.75 19.5 8.25 12l7.5-7.5" />
       </svg>
+    <% end %>
+    <div class="flex-grow text-center text-xl font-medium">
+      <%= page_title(yield(:title)) %>
     </div>
-    <div class="navbar-center">
-      <a class="btn btn-ghost text-xl mx-auto">ログイン前</a>
-    </div>
+    <div class="flex-shrink-0 w-8 h-8"></div>
   </div>
 </header>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -14,7 +14,7 @@
       </svg>
     <% end %>
     <div class="flex-grow text-center text-xl font-medium">
-      <%= page_title(yield(:title)) %>
+      <%= page_title(yield(:title), include_base: false) %>
     </div>
     <div class="flex-shrink-0 w-8 h-8"></div>
   </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer footer-center bg-base-200 text-base-content rounded p-10">
+<footer class="bottom-0 absolute footer footer-center bg-base-200 text-base-content rounded p-10">
   <nav class="grid grid-flow-col gap-4">
     <%= link_to '利用規約', '#', class: 'link link-hover' %>
     <%= link_to 'プライバシーポリシー', '#', class: 'link link-hover' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -26,7 +26,7 @@
         </ul>
       </div>
       <div class="flex-grow text-center text-xl font-medium">
-        <%= page_title(yield(:title)) %>
+        <%= page_title(yield(:title), include_base: false) %>
       </div>
     <div class="flex-shrink-0 w-8 h-8"></div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,36 +1,7 @@
 <header>
-  <div class="navbar bg-base-100">
-    <div class="navbar-start">
-      <div class="dropdown">
-        <div tabindex="0" role="button" class="btn btn-ghost btn-circle">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M4 6h16M4 12h16M4 18h7" />
-          </svg>
-        </div>
-        <ul
-          tabindex="0"
-          class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow">
-          <li><%= link_to 'レビューをつくる', new_review_path %></li>
-          <li><%= link_to 'レビューをみる', reviews_path %></li>
-          <!-- <li><%= link_to 'ユーザー設定', '#' %></li> -->
-          <li><%= link_to 'ログアウト', logout_path, method: :delete, data: { turbo_method: :delete } %></li>
-        </ul>
-      </div>
-    </div>
-    <div class="navbar-center">
-      <a class="btn btn-ghost text-xl">タイトル</a>
-    </div>
-    <div class="navbar-end">
-      <button class="btn btn-ghost btn-circle">
+  <div class="flex items-center justify-between h-12 px-4 bg-base-200">
+    <div class="dropdown">
+      <div tabindex="0" role="button" class="btn btn-ghost btn-circle">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           class="h-5 w-5"
@@ -41,26 +12,22 @@
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width="2"
-            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            d="M4 6h16M4 12h16M4 18h7" />
         </svg>
-      </button>
-      <button class="btn btn-ghost btn-circle">
-        <div class="indicator">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-5 w-5"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-          </svg>
-          <span class="badge badge-xs badge-primary indicator-item"></span>
         </div>
-      </button>
-    </div>
+        <ul
+          tabindex="0"
+          class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow"
+        >
+          <li><%= link_to 'レビューをつくる', new_review_path %></li>
+          <li><%= link_to 'レビューをみる', reviews_path %></li>
+          <!-- <li><%= link_to 'ユーザー設定', '#' %></li> -->
+          <li><%= link_to 'ログアウト', logout_path, method: :delete, data: { turbo_method: :delete } %></li>
+        </ul>
+      </div>
+      <div class="flex-grow text-center text-xl font-medium">
+        <%= page_title(yield(:title)) %>
+      </div>
+    <div class="flex-shrink-0 w-8 h-8"></div>
   </div>
 </header>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -51,3 +51,8 @@
         <%= link_to '新規登録', new_user_path, class: "btn btn-link" %>
     </div>
 </div>
+<style>
+    header {
+        display: none;
+    }
+</style>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,31 +1,32 @@
+<% content_for(:title, 'ログイン') %>
 <div class="container">
-<%= form_with url: login_path do |f| %>
-  <label class="input input-bordered flex items-center gap-2">
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 16 16"
-      fill="currentColor"
-      class="h-4 w-4 opacity-70">
-      <path
-        d="M2.5 3A1.5 1.5 0 0 0 1 4.5v.793c.026.009.051.02.076.032L7.674 8.51c.206.1.446.1.652 0l6.598-3.185A.755.755 0 0 1 15 5.293V4.5A1.5 1.5 0 0 0 13.5 3h-11Z" />
-      <path
-        d="M15 6.954 8.978 9.86a2.25 2.25 0 0 1-1.956 0L1 6.954V11.5A1.5 1.5 0 0 0 2.5 13h11a1.5 1.5 0 0 0 1.5-1.5V6.954Z" />
-    </svg>
-    <%= f.text_field :email, class: "grow", placeholder: "Email" %>
-  </label>
-  <label class="input input-bordered flex items-center gap-2">
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 16 16"
-      fill="currentColor"
-      class="h-4 w-4 opacity-70">
-      <path
-        fill-rule="evenodd"
-        d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z"
-        clip-rule="evenodd" />
-    </svg>
-    <%= f.password_field :password, class: "grow", placeholder: "Password" %>
-  </label>
-  <%= f.submit "sign in", class: "btn mb-4" %>
-<% end %>
+  <%= form_with url: login_path do |f| %>
+    <label class="input input-bordered flex items-center gap-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        class="h-4 w-4 opacity-70">
+        <path
+          d="M2.5 3A1.5 1.5 0 0 0 1 4.5v.793c.026.009.051.02.076.032L7.674 8.51c.206.1.446.1.652 0l6.598-3.185A.755.755 0 0 1 15 5.293V4.5A1.5 1.5 0 0 0 13.5 3h-11Z" />
+        <path
+          d="M15 6.954 8.978 9.86a2.25 2.25 0 0 1-1.956 0L1 6.954V11.5A1.5 1.5 0 0 0 2.5 13h11a1.5 1.5 0 0 0 1.5-1.5V6.954Z" />
+      </svg>
+      <%= f.text_field :email, class: "grow", placeholder: "Email" %>
+    </label>
+    <label class="input input-bordered flex items-center gap-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        class="h-4 w-4 opacity-70">
+        <path
+          fill-rule="evenodd"
+          d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z"
+          clip-rule="evenodd" />
+      </svg>
+      <%= f.password_field :password, class: "grow", placeholder: "Password" %>
+    </label>
+    <%= f.submit "sign in", class: "btn mb-4" %>
+  <% end %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, 'ユーザー登録') %>
 <div class="container">
   <%= form_with model: @user do |f| %>
     <label class="input input-bordered flex items-center gap-2">


### PR DESCRIPTION
# 概要
ヘッダー、フッターまわりのデザイン・挙動修正

# テストケース

- [x] トップページにヘッダーが表示されない
- [x] titleが動的に出力される（ReviewReflect | {ページタイトル}）
- [x] ヘッダーに各ページ名が表示される
- [x] ログイン前ヘッダー
  - [x] タイトルが中央寄せに配置されている
  - [x] ＜アイコンから一つ前のページに戻れる
- [x] ログイン後ヘッダ
  - [x] タイトルが中央寄せに配置されている
  - [x] メニューアイコンからメニューが開く
  - [x] メニューアイコンから各リンクに飛べる
- [x] フッター
  - [x] 最下部に表示される
  - [x] コンテンツが少ないページでは表示領域の最下部に表示される
  - [x] レビュー作成ページに出ていない