### PR TITLE
ユーザー登録・ログインページの修正

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,7 +7,7 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_to root_path, success: 'ログインしました'
+      redirect_to new_review_path, success: 'ログインしました'
     else
       flash.now[:danger] = 'ログインに失敗しました'
       render :new, status: :unprocessable_entity

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, 'ログイン') %>
-<div class="container">
-  <%= form_with url: login_path do |f| %>
-    <label class="input input-bordered flex items-center gap-2">
+<div class="container mx-auto p-8 flex flex-col items-center w-full max-w-md">
+  <%= form_with url: login_path, class: "w-full" do |f| %>
+    <label class="input input-bordered flex items-center mb-4 w-full">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
@@ -12,9 +12,9 @@
         <path
           d="M15 6.954 8.978 9.86a2.25 2.25 0 0 1-1.956 0L1 6.954V11.5A1.5 1.5 0 0 0 2.5 13h11a1.5 1.5 0 0 0 1.5-1.5V6.954Z" />
       </svg>
-      <%= f.text_field :email, class: "grow", placeholder: "Email" %>
+      <%= f.text_field :email, class: "grow", placeholder: "メールアドレス" %>
     </label>
-    <label class="input input-bordered flex items-center gap-2">
+    <label class="input input-bordered flex items-center mb-4 w-full">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
@@ -25,8 +25,10 @@
           d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z"
           clip-rule="evenodd" />
       </svg>
-      <%= f.password_field :password, class: "grow", placeholder: "Password" %>
+      <%= f.password_field :password, class: "grow", placeholder: "パスワード" %>
     </label>
-    <%= f.submit "sign in", class: "btn mb-4" %>
+    <div class="flex justify-center w-full mb-4">
+      <%= f.submit "ログイン", class: "btn mb-4" %>
+    </div>
   <% end %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, 'ユーザー登録') %>
-<div class="container">
-  <%= form_with model: @user do |f| %>
-    <label class="input input-bordered flex items-center gap-2">
+<div class="container mx-auto p-8 flex flex-col items-center w-full max-w-md">
+  <%= form_with model: @user, class: "w-full" do |f| %>
+    <label class="input input-bordered flex items-center mb-4 w-full">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
@@ -12,9 +12,9 @@
         <path
           d="M15 6.954 8.978 9.86a2.25 2.25 0 0 1-1.956 0L1 6.954V11.5A1.5 1.5 0 0 0 2.5 13h11a1.5 1.5 0 0 0 1.5-1.5V6.954Z" />
       </svg>
-      <%= f.text_field :email, class: "grow", placeholder: "Email" %>
+      <%= f.text_field :email, class: "grow", placeholder: "メールアドレス" %>
     </label>
-    <label class="input input-bordered flex items-center gap-2">
+    <label class="input input-bordered flex items-center mb-4 w-full">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
@@ -23,9 +23,9 @@
         <path
           d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM12.735 14c.618 0 1.093-.561.872-1.139a6.002 6.002 0 0 0-11.215 0c-.22.578.254 1.139.872 1.139h9.47Z" />
       </svg>
-      <%= f.text_field :name, class: "grow", placeholder: "Username" %>
+      <%= f.text_field :name, class: "grow", placeholder: "ニックネーム" %>
     </label>
-    <label class="input input-bordered flex items-center gap-2">
+    <label class="input input-bordered flex items-center mb-4 w-full">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
@@ -36,9 +36,9 @@
           d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z"
           clip-rule="evenodd" />
       </svg>
-      <%= f.password_field :password, class: "grow", placeholder: "Password" %>
+      <%= f.password_field :password, class: "grow", placeholder: "パスワード" %>
     </label>
-    <label class="input input-bordered flex items-center gap-2">
+    <label class="input input-bordered flex items-center mb-4 w-full">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
@@ -49,8 +49,10 @@
           d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z"
           clip-rule="evenodd" />
       </svg>
-      <%= f.password_field :password_confirmation, class: "grow", placeholder: "Password Confirmation" %>
+      <%= f.password_field :password_confirmation, class: "grow", placeholder: "確認用パスワード" %>
     </label>
-    <%= f.submit "sign up", class: "btn mb-4" %>
+    <div class="flex justify-center w-full mb-4">
+      <%= f.submit "登録", class: "btn" %>
+    </div>
   <% end %>
 </div>


### PR DESCRIPTION
テストケース
- [x] ユーザー登録ページ
  - [x] 登録ボタンを中央寄せにする
  - [x] 入力欄を中央寄せにする
  - [x] 要素間に余白をもたせる
  - [x] プレースホルダー・ボタンを日本語にする
  - [x] 登録後にログイン状態になっている
  - [x] 登録後の飛び先をレビュー作成ページにする
- [x] ログインページ
  - [x] ログインボタンを中央寄せにする
  - [x] 入力欄を中央寄せにする
  - [x] 要素間に余白をもたせる
  - [x] プレースホルダー・ボタンを日本語にする
  - [x] ログイン後の飛び先をレビュー作成ページにする