### PR TITLE
バリデーションエラー時にメッセージを出す

### DIFF
--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,6 +1,9 @@
 <div id="review_form" class="max-w-4xl w-full space-y-1 h-full">
   <%= form_with model: @review, url: review_path(@review), data: { turbo: false, controller: 'review', review_character_count_value: 140 } do |f| %>
     <div class="mb-4">
+      <%= render 'shared/error_messages', object: f.object %>
+    </div>
+    <div class="mb-4">
       <%= f.label "上限文字数" %>
       <%= f.number_field :character_count, class: "grow input input-bordered flex items-center w-full", data: { review_target: "characterCount" } %>
     </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <header>
   <div class="flex items-center justify-between h-12 px-4 bg-base-200">
-    <%= link_to :back, class: "flex-shrink-0" do %>
+    <%= link_to root_path, class: "flex-shrink-0" do %>
       <svg 
         xmlns="http://www.w3.org/2000/svg"
         class="h-5 w-5"

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_explanation" class="alert bg-red-100 text-red-700">
+    <ul class="mb-0 text-left">
+      <% object.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,9 @@
 <% content_for(:title, 'ユーザー登録') %>
 <div class="container mx-auto px-8 pt-8 pb-60 flex flex-col items-center w-full max-w-md">
   <%= form_with model: @user, class: "w-full" do |f| %>
+    <div class="mb-4">
+      <%= render 'shared/error_messages', object: f.object %>
+    </div>
     <label class="input input-bordered flex items-center mb-4 w-full">
       <svg
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
# 概要
- バリデーションエラー時にエラー内容のメッセージが出るようにする
- 日本語化対応はMVPリリース後のタスクのため翻訳はなし
- バリデーションエラー時に戻るボタンを押すとトップページ（root_path）に戻れない問題の解消

# テストケース

- [ ] 以下のページでバリデーションエラーメッセ―ジが表示される
  - [ ] 新規ユーザー登録
  - [ ] レビュー登録
- [ ] 以下のページでバリデーションエラーになった際、ヘッダの戻るボタンでトップページに戻れる
  - [ ] 新規ユーザー登録
  - [ ] ログイン